### PR TITLE
Import pyliquid via submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pyliquid"]
+	path = pyliquid
+	url = https://github.com/Snufkin0866/pyliquid.git

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## 使い方
 - 使い方はそれほど難しくありません．やることは大きく分けて，1. configファイルの編集2. cronの設定．（cronでなくても定時実行できればなんでも良い）です．
 - python versionは3系です．特別なライブラリは必要ありませんが，pyliquidが必要です．
-- pyliquid.pyと同じディレクトリに置いてください．
+- `git clone https://github.com/Snufkin0866/pyliquidpnl.git --recursive` で clone すれば、pyliquid も合わせて clone されます。
 pyliquid→https://github.com/Snufkin0866/pyliquid
 ccxt版を使う場合はpyliquidは必要ありません．→https://github.com/gokoro/pyliquidpnl-ccxt
 - config_sample.pyをリネームしたconfig.pyにAPI情報と，Discordの損益部屋で取得したWEBHOOKURLを入力してください．なお，WEBHOOKの名前は参加者様の名前と

--- a/pyliquid_pnl.py
+++ b/pyliquid_pnl.py
@@ -24,7 +24,7 @@ register_matplotlib_converters()
 import seaborn as sns
 sns.set()
 
-import pyliquid
+from pyliquid import pyliquid
 import config
 
 


### PR DESCRIPTION
git のサブモジュールから pyliqud を参照するようにしたので、別途 pyliquid を clone してファイルをコピーしてくる、といった作業が必要なくなります

（clone 済みの既存ローカルリポジトリでサブモジュールを持ってくるには `git submodule update` の実行が必要です）